### PR TITLE
option to preserve permission bits

### DIFF
--- a/rofs-filtered.c
+++ b/rofs-filtered.c
@@ -120,6 +120,7 @@ struct rofs_config {
     char *rw_path;
     char *config;
     int invert;
+    int preserve_perm; 
 };
 
 // Global to store our configuration (the option parsing results)
@@ -339,7 +340,9 @@ static int callback_getattr(const char *path, struct stat *st_data) {
         return -errno;
     }
     // Remove write permissions = chmod a-w
-    st_data->st_mode &= ~(S_IWUSR | S_IWGRP | S_IWOTH);
+    if (!conf.preserve_perm) {
+      st_data->st_mode &= ~(S_IWUSR | S_IWGRP | S_IWOTH);
+    }
     return 0;
 }
 
@@ -731,6 +734,7 @@ static struct fuse_opt rofs_opts[] = {
     ROFS_OPT("config=%s",       config, 0),
     ROFS_OPT("-c %s",           config, 0),
     ROFS_OPT("invert",          invert, 1),
+    ROFS_OPT("preserve-perm",   preserve_perm, 1),
 
     FUSE_OPT_KEY("-V",          KEY_VERSION),
     FUSE_OPT_KEY("--version",   KEY_VERSION),
@@ -753,6 +757,7 @@ static int rofs_opt_proc(void *data, const char *arg, int key, struct fuse_args 
                 "    -o source=DIR           directory to mount as read-only and filter\n"
                 "    -o config=CONFIG_FILE   config file path (default: %s)\n"
                 "    -o invert               the config file specifies files to allow\n"
+                "    -o preserve-perm        do not clear write permission\n"
                 "\n"
                 , outargs->argv[0], default_config_file);
         // Let fuse print out its help text as well...

--- a/rofs-filtered.c
+++ b/rofs-filtered.c
@@ -120,7 +120,7 @@ struct rofs_config {
     char *rw_path;
     char *config;
     int invert;
-    int preserve_perm; 
+    int preserve_perms; 
 };
 
 // Global to store our configuration (the option parsing results)
@@ -340,7 +340,7 @@ static int callback_getattr(const char *path, struct stat *st_data) {
         return -errno;
     }
     // Remove write permissions = chmod a-w
-    if (!conf.preserve_perm) {
+    if (!conf.preserve_perms) {
       st_data->st_mode &= ~(S_IWUSR | S_IWGRP | S_IWOTH);
     }
     return 0;
@@ -734,7 +734,7 @@ static struct fuse_opt rofs_opts[] = {
     ROFS_OPT("config=%s",       config, 0),
     ROFS_OPT("-c %s",           config, 0),
     ROFS_OPT("invert",          invert, 1),
-    ROFS_OPT("preserve-perm",   preserve_perm, 1),
+    ROFS_OPT("preserve-perms",   preserve_perms, 1),
 
     FUSE_OPT_KEY("-V",          KEY_VERSION),
     FUSE_OPT_KEY("--version",   KEY_VERSION),
@@ -757,7 +757,7 @@ static int rofs_opt_proc(void *data, const char *arg, int key, struct fuse_args 
                 "    -o source=DIR           directory to mount as read-only and filter\n"
                 "    -o config=CONFIG_FILE   config file path (default: %s)\n"
                 "    -o invert               the config file specifies files to allow\n"
-                "    -o preserve-perm        do not clear write permission\n"
+                "    -o preserve-perms        do not clear write permission\n"
                 "\n"
                 , outargs->argv[0], default_config_file);
         // Let fuse print out its help text as well...


### PR DESCRIPTION
This option allows preservation of the write permission bit, which is useful when, e.g., using rofs-filtered when creating backups.