### PR TITLE
Check both type *and* pattern if invert is given

### DIFF
--- a/rofs-filtered.c
+++ b/rofs-filtered.c
@@ -403,10 +403,13 @@ static int should_hide(const char *name, mode_t mode) {
     for (int i = 0; i < modes_count; ++i)
         if (mode == modes[i]) {
             log_msg(LOG_DEBUG, "type: %07o %s", mode, name);
+            if (conf.invert)
+                goto allow_type;
             return !conf.invert;
          }
     if (conf.invert && mode != S_IFREG && mode != S_IFDIR)
         return conf.invert;
+  allow_type:
     if (!regexec(&pattern, name, 0, NULL, 0)) {
         // We have a match.
         log_msg(LOG_DEBUG, "match: %s", name);


### PR DESCRIPTION
This patch will allow rofs-filtered to match symbolic links with patterns in `-o invert` mode. It makes more sense in my opinion than including all files of a particular type.